### PR TITLE
feat: nasne 特殊文字変換を TypeScript に移植

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,12 @@ npm run build         # ビルド（ESM + CJS）
 src/
 ├── index.ts        # エントリポイント（public API）
 ├── endpoints.ts    # エンドポイント定義・URL構築・クエリ構築
+├── format-text.ts  # 特殊Unicode→日本語変換
 ├── constants.ts    # 定数（ポート番号・タイムアウト）
 └── types.ts        # 型定義
 tests/
-└── endpoints.test.ts
+├── endpoints.test.ts
+└── format-text.test.ts
 ```
 
 ## 注意事項

--- a/src/format-text.ts
+++ b/src/format-text.ts
@@ -1,0 +1,25 @@
+/**
+ * nasne 特殊文字変換
+ *
+ * nasne が JSON データ内で返す Private Use Area の Unicode 文字を、
+ * 人間が読める日本語表記（例: [終], [新]）に変換する。
+ */
+
+/** nasne の特殊文字と変換後テキストのマッピング */
+const SPECIAL_CHAR_MAP: ReadonlyArray<[RegExp, string]> = [
+  [/\uE195/g, "[終]"],
+  [/\uE193/g, "[新]"],
+  [/\uE0FE/g, "[字]"],
+  [/\uE184/g, "[解]"],
+  [/\uE183/g, "[多]"],
+  [/\uE180/g, "[デ]"],
+];
+
+/**
+ * nasne の特殊文字を読みやすい形式に変換する
+ *
+ * @param text - 変換する文字列（通常は nasne API のレスポンス JSON）
+ * @returns 特殊文字を日本語表記に置換した文字列
+ */
+export const formatText = (text: string): string =>
+  SPECIAL_CHAR_MAP.reduce((result, [pattern, replacement]) => result.replace(pattern, replacement), text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@
  * パッケージの公開 API をここから再エクスポートする
  */
 export { getUrl, getQueryString, ALL_ENDPOINTS } from "./endpoints.js";
+export { formatText } from "./format-text.js";
 export type { EndpointName, QueryParams, CheckEndpointResult } from "./types.js";

--- a/tests/format-text.test.ts
+++ b/tests/format-text.test.ts
@@ -1,0 +1,59 @@
+/**
+ * nasne 特殊文字変換機能のテスト
+ * nasne が返す Private Use Area の Unicode 文字を日本語表記に変換する
+ */
+import { describe, it, expect } from "vitest";
+import { formatText } from "../src/format-text.js";
+
+describe("formatText", () => {
+  describe("特殊文字の変換", () => {
+    it("\\uE195 を [終] に変換する", () => {
+      expect(formatText("\uE195番組タイトル")).toBe("[終]番組タイトル");
+    });
+
+    it("\\uE193 を [新] に変換する", () => {
+      expect(formatText("\uE193番組タイトル")).toBe("[新]番組タイトル");
+    });
+
+    it("\\uE0FE を [字] に変換する", () => {
+      expect(formatText("\uE0FE番組タイトル")).toBe("[字]番組タイトル");
+    });
+
+    it("\\uE184 を [解] に変換する", () => {
+      expect(formatText("\uE184番組タイトル")).toBe("[解]番組タイトル");
+    });
+
+    it("\\uE183 を [多] に変換する", () => {
+      expect(formatText("\uE183番組タイトル")).toBe("[多]番組タイトル");
+    });
+
+    it("\\uE180 を [デ] に変換する", () => {
+      expect(formatText("\uE180番組タイトル")).toBe("[デ]番組タイトル");
+    });
+  });
+
+  describe("複数の特殊文字が含まれる場合", () => {
+    it("複数の特殊文字をすべて変換する", () => {
+      expect(formatText("\uE195\uE193ドラマタイトル")).toBe("[終][新]ドラマタイトル");
+    });
+
+    it("同一の特殊文字が複数回出現する場合もすべて変換する", () => {
+      expect(formatText("\uE195タイトル\uE195")).toBe("[終]タイトル[終]");
+    });
+  });
+
+  describe("変換対象外の文字列", () => {
+    it("特殊文字を含まない文字列はそのまま返す", () => {
+      expect(formatText("通常のテキスト")).toBe("通常のテキスト");
+    });
+
+    it("空文字列はそのまま返す", () => {
+      expect(formatText("")).toBe("");
+    });
+
+    it("JSON 形式の文字列も正しく変換する", () => {
+      const input = JSON.stringify({ title: "\uE195ドラマ" });
+      expect(formatText(input)).toContain("[終]ドラマ");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `src/format-text.ts`: `formatText()` を TypeScript で実装（旧 `util/formatText.js` を移植）
- 変換マッピングを定数配列 `SPECIAL_CHAR_MAP` として整理（6種の特殊文字対応）
- `tests/format-text.test.ts`: 各特殊文字の変換・複数同時変換・空文字列を TDD で検証（11件）

## Test plan

- [ ] `npm run lint` でエラーなし
- [ ] `npm run type-check` でエラーなし
- [ ] `npm test` で 33 件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * テキスト内の特殊文字を日本語表記に変換する機能が利用できるようになりました。

* **テスト**
  * 新しいテキスト変換機能向けのテストスイートが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->